### PR TITLE
fix is_optional value not always set

### DIFF
--- a/ivcap_service/tool_definition.py
+++ b/ivcap_service/tool_definition.py
@@ -161,6 +161,7 @@ def _generate_function_description(func: Callable, name: Optional[str] = None, e
         # Get the correct type from the Pydantic model
         field_type = field_info.get('type', None)
 
+        is_optional = False
         # If type is not available in the schema, try to get it from the model's __annotations__
         if field_type is None and hasattr(pydantic_model_class, '__annotations__'):
             annotation = pydantic_model_class.__annotations__.get(field_name)
@@ -179,7 +180,6 @@ def _generate_function_description(func: Callable, name: Optional[str] = None, e
                 field_type = 'Any'
         else:
             # Handle optional fields
-            is_optional = False
             if 'default' in field_info or field_name not in model_schema.get('required', []):
                 is_optional = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ivcap_service"
-version = "0.6.4"
+version = "0.6.5"
 description = "SDK library for building services for the IVCAP platform"
 
 authors = ["Max Ott <max.ott@csiro.au>"]


### PR DESCRIPTION
This PR fix the issue that `is_optional` is not always set, but referred later , which cause exception like below:

```
File "/Users/maj025/Data61/work_directory/science_digital/ivcap_tool_genewhisperer/tool-service.py", line 179, in <module>
    start_tool_server(service)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/Users/maj025/Data61/work_directory/science_digital/ivcap_tool_genewhisperer/.venv/lib/python3.13/site-packages/ivcap_ai_tool/server.py", line 91, in start_tool_server
    print_tool_definition(tool.worker_fn)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/Users/maj025/Data61/work_directory/science_digital/ivcap_tool_genewhisperer/.venv/lib/python3.13/site-packages/ivcap_service/tool_definition.py", line 47, in print_tool_definition
    td = create_tool_definition(fn, name=name, service_id=service_id, description=description, id_prefix=id_prefix)
  File "/Users/maj025/Data61/work_directory/science_digital/ivcap_tool_genewhisperer/.venv/lib/python3.13/site-packages/ivcap_service/tool_definition.py", line 60, in create_tool_definition
    signature, description = _generate_function_description(fn, name, exclude_types=[ExecutionContext])
                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/maj025/Data61/work_directory/science_digital/ivcap_tool_genewhisperer/.venv/lib/python3.13/site-packages/ivcap_service/tool_definition.py", line 213, in _generate_function_description
    if is_optional and not field_type.startswith('Optional['):
       ^^^^^^^^^^^
```